### PR TITLE
Update 6 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -18,14 +18,14 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot configuration rest api wifimanager</tags>
     <dependencies>
       <dependency id="Mako.nanoFramework.Json" version="2.2.8" />
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.16.4123" />
-      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.15.16509" />
-      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.15.12255" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.17.24294" />
+      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.16.38329" />
+      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.16.3164" />
       <dependency id="MakoIoT.Device.Services.DependencyInjection" version="1.0.17.52441" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.17.36444" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.16.28757" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.15.28638" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.15.15068" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.17.20740" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.16.6117" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.16.35584" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.1.17335" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.15.64242" />
       <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -30,15 +30,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.16.4123\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.17.24294\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.15.16509\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.16.38329\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.15.12255\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.16.3164\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -50,15 +50,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.16.28757\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.17.20740\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.15.28638\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.16.6117\lib\MakoIoT.Device.Services.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.15.15068\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.16.35584\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker">

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.16.4123" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.15.16509" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.15.12255" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.17.24294" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.16.38329" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.16.3164" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.DependencyInjection" version="1.0.17.52441" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.17.36444" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.16.28757" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.15.28638" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.15.15068" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.17.20740" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.16.6117" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.16.35584" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.1.17335" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.15.64242" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.16.4123 to 1.0.17.24294</br>Bumps MakoIoT.Device.Services.Configuration.Metadata from 1.0.15.16509 to 1.0.16.38329</br>Bumps MakoIoT.Device.Services.ConfigurationManager from 1.0.15.12255 to 1.0.16.3164</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.16.28757 to 1.0.17.20740</br>Bumps MakoIoT.Device.Services.Server from 1.0.15.28638 to 1.0.16.6117</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.15.15068 to 1.0.16.35584</br>
[version update]

### :warning: This is an automated update. :warning:
