### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -17,13 +17,13 @@
     <description>REST API for configuration with MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot configuration rest api wifimanager</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.27.26144" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.29.64214" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.27.36284" />
       <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.32.62963" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.34.44535" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.26.61682" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.29.32513" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.30.34884" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.30.11229" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.31.12836" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.31.17475" />
       <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
@@ -34,7 +34,7 @@
       <dependency id="nanoFramework.System.Device.Wifi" version="1.5.54" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.38" />
       <dependency id="nanoFramework.System.Net" version="1.10.52" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.99" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.102" />
       <dependency id="nanoFramework.System.Text" version="1.2.37" />
       <dependency id="nanoFramework.System.Threading" version="1.1.19" />
       <dependency id="nanoFramework.Json" version="2.2.99" />

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -30,7 +30,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.27.26144\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.29.64214\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -47,11 +47,11 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.26.61682\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.29.32513\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.30.11229\lib\MakoIoT.Device.Services.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.30.34884\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.31.12836\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -103,8 +103,8 @@
       <HintPath>..\..\packages\nanoFramework.System.Net.1.10.52\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.99.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.99\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.102.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.102\lib\System.Net.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.19.33722, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.27.26144" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.29.64214" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.27.36284" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.32.62963" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.34.44535" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.26.61682" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.29.32513" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.30.34884" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.30.11229" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.31.12836" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.31.17475" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
@@ -19,7 +19,7 @@
   <package id="nanoFramework.System.Device.Wifi" version="1.5.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.38" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.10.52" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.99" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.102" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.37" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.19" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.27.26144 to 1.0.29.64214</br>Bumps MakoIoT.Device.Services.Server from 1.0.29.32513 to 1.0.30.11229</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.30.34884 to 1.0.31.12836</br>Bumps nanoFramework.System.Net.Http from 1.5.99 to 1.5.102</br>
[version update]

### :warning: This is an automated update. :warning:
