### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -21,7 +21,7 @@
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.30.32136" />
       <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.43.17601" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.30.24296" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.31.54540" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.33.42549" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.35.41595" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" />

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -46,7 +46,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.30.24296\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.31.54540\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -4,7 +4,7 @@
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.30.32136" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.43.17601" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.30.24296" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.31.54540" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.33.42549" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.35.41595" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Mediator from 1.0.30.24296 to 1.0.31.54540</br>
[version update]

### :warning: This is an automated update. :warning:
