### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -20,7 +20,7 @@
       <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.32.19851" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.35.8833" />
       <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.52.48346" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.40.57355" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.32.35604" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.39.37862" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.38.49935" />
@@ -28,7 +28,7 @@
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.407" />
-      <dependency id="nanoFramework.Logging" version="1.1.74" />
+      <dependency id="nanoFramework.Logging" version="1.1.76" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
       <dependency id="nanoFramework.System.Device.Wifi" version="1.5.71" />

--- a/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/MakoIoT.Device.Services.ConfigurationApi.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/MakoIoT.Device.Services.ConfigurationApi.Test.nfproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.40.57355\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.41.25178\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -42,8 +42,8 @@
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.74.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.74\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.76.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.76\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.TestFramework, Version=2.1.87.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.40.57355" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.74" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.76" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="2.1.87" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -42,7 +42,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.40.57355\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.41.25178\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -77,8 +77,8 @@
       <HintPath>..\..\packages\nanoFramework.Json.2.2.103\lib\nanoFramework.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.74.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.74\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.76.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.76\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -3,7 +3,7 @@
   <package id="MakoIoT.Device.Services.Configuration" version="1.0.32.19851" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.35.8833" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.52.48346" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.40.57355" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.32.35604" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.39.37862" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.38.49935" targetFramework="netnano1.0" />
@@ -13,7 +13,7 @@
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.407" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.103" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.74" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.76" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Wifi" version="1.5.71" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.40.57355 to 1.0.41.25178</br>Bumps nanoFramework.Logging from 1.1.74 to 1.1.76</br>
[version update]

### :warning: This is an automated update. :warning:
