### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -21,8 +21,8 @@
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.40.54426" />
       <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.61.46744" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.43.29288" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.36.36218" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.43.59647" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.37.22301" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.44.20713" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.45.4707" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.27.50780" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" />

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -46,11 +46,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.36.36218\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.37.22301\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.43.59647\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.44.20713\lib\MakoIoT.Device.Services.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -4,8 +4,8 @@
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.40.54426" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.61.46744" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.43.29288" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.36.36218" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.43.59647" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.37.22301" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.44.20713" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.45.4707" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.27.50780" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Mediator from 1.0.36.36218 to 1.0.37.22301</br>Bumps MakoIoT.Device.Services.Server from 1.0.43.59647 to 1.0.44.20713</br>
[version update]

### :warning: This is an automated update. :warning:
