### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -19,9 +19,9 @@
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.40.13779" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.42.54736" />
-      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.80.10722" />
+      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.81.54242" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.40.12180" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.41.33870" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.53.21457" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.56.42901" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.28.14340" />

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -36,14 +36,16 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.42.54736\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.80.10722\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.81.54242\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.46.2905\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.40.12180\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.41.33870\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.53.21457\lib\MakoIoT.Device.Services.Server.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="MakoIoT.Device.Services.Configuration" version="1.0.40.13779" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.42.54736" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.80.10722" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.81.54242" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.40.12180" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.41.33870" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.53.21457" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.56.42901" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.28.14340" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.ConfigurationManager from 1.0.80.10722 to 1.0.81.54242</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.40.12180 to 1.0.41.33870</br>
[version update]

### :warning: This is an automated update. :warning:
