### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -19,11 +19,11 @@
     <dependencies>
       <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.57.55232" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.49.41121" />
-      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.126.31902" />
+      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.127.45116" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.52.56154" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.72.44109" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.83.42304" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.84.20731" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.37.26660" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.37.35071" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -35,7 +35,7 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.49.41121\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.126.31902\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.127.45116\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.47.44904\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
@@ -47,7 +47,7 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.72.44109\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.83.42304\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.84.20731\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.37.26660\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -2,11 +2,11 @@
 <packages>
   <package id="MakoIoT.Device.Services.Configuration" version="1.0.57.55232" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.49.41121" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.126.31902" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.127.45116" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.52.56154" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.72.44109" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.83.42304" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.84.20731" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.37.26660" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.37.35071" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.ConfigurationManager from 1.0.126.31902 to 1.0.127.45116</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.83.42304 to 1.0.84.20731</br>
[version update]

### :warning: This is an automated update. :warning:
