### PR TITLE
Update 19 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -20,24 +20,24 @@
       <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.62.51969" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.51.20103" />
       <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.138.9072" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.57.42352" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.58.36645" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.77.42584" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.90.47072" />
-      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.41.39143" />
-      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.37.35071" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
-      <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.644" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.18" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.45" />
-      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.91" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.59" />
-      <dependency id="nanoFramework.System.Net" version="1.11.1" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.150" />
-      <dependency id="nanoFramework.System.Text" version="1.2.54" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.32" />
-      <dependency id="nanoFramework.Json" version="2.2.152" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.11" />
+      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.42.25254" />
+      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.38.1040" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />
+      <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.761" />
+      <dependency id="nanoFramework.Runtime.Events" version="1.11.29" />
+      <dependency id="nanoFramework.System.Collections" version="1.5.59" />
+      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.115" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.86" />
+      <dependency id="nanoFramework.System.Net" version="1.11.27" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.175" />
+      <dependency id="nanoFramework.System.Text" version="1.3.16" />
+      <dependency id="nanoFramework.System.Threading" version="1.1.46" />
+      <dependency id="nanoFramework.Json" version="2.2.176" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.25" />
     </dependencies>
   </metadata>
   <files>

--- a/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/MakoIoT.Device.Services.ConfigurationApi.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/MakoIoT.Device.Services.ConfigurationApi.Test.nfproj
@@ -31,22 +31,22 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.48.22567\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.50.35966\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.11\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.25.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.25\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.113.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.113\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.140.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.140\lib\nanoFramework.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=3.0.47.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.47\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=3.0.67.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.67\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.47\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.67\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.113" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="3.0.47" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.140" targetFramework="netnano1.0" />
+  <package id="nanoFramework.TestFramework" version="3.0.67" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.props" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.props')" />
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props')" />
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
   </PropertyGroup>
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.DhcpServer, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.644\lib\Iot.Device.DhcpServer.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.761\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.62.51969\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
@@ -38,10 +38,10 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.138.9072\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.48.22567\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.50.35966\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.57.42352\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.58.36645\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.77.42584\lib\MakoIoT.Device.Services.Server.dll</HintPath>
@@ -50,43 +50,43 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.90.47072\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.41.39143\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.42.25254\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.37.35071\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.38.1040\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
-    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.16.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.16.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.11\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.25.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.25\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Json, Version=2.2.152.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Json.2.2.152\lib\nanoFramework.Json.dll</HintPath>
+    <Reference Include="nanoFramework.Json, Version=2.2.176.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Json.2.2.176\lib\nanoFramework.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.29\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections, Version=1.5.45.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.45\lib\nanoFramework.System.Collections.dll</HintPath>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.59\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
+    <Reference Include="nanoFramework.System.Text, Version=1.3.16.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Text.1.3.16\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.91.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.91\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.115.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.115\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.86.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.86\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.1\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.27.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.27\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.150.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.150\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.175.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.175\lib\System.Net.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>
+    <Reference Include="System.Threading, Version=1.1.46.1709, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.46\lib\System.Threading.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -102,8 +102,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.props'))" />
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.props'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.146\build\Nerdbank.GitVersioning.targets')" />
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.7.115\build\Nerdbank.GitVersioning.targets')" />
 </Project>

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -3,23 +3,23 @@
   <package id="MakoIoT.Device.Services.Configuration" version="1.0.62.51969" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.51.20103" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.138.9072" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.48.22567" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.57.42352" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.58.36645" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.77.42584" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.90.47072" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.41.39143" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.String" version="1.0.37.35071" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.1.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.644" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Json" version="2.2.152" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Collections" version="1.5.45" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.91" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.1" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.150" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="Nerdbank.GitVersioning" version="3.6.146" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.42.25254" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.String" version="1.0.38.1040" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.25" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.761" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Json" version="2.2.176" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.29" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.59" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.115" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.86" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.27" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.175" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Text" version="1.3.16" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Threading" version="1.1.46" targetFramework="netnano1.0" />
+  <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.48.22567 to 1.0.50.35966</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.57.42352 to 1.0.58.36645</br>Bumps MakoIoT.Device.Utilities.Invoker from 1.0.41.39143 to 1.0.42.25254</br>Bumps MakoIoT.Device.Utilities.String from 1.0.37.35071 to 1.0.38.1040</br>Bumps nanoFramework.CoreLibrary from 1.15.5 to 1.16.11</br>Bumps nanoFramework.DependencyInjection from 1.1.11 to 1.1.25</br>Bumps nanoFramework.Iot.Device.DhcpServer from 1.2.644 to 1.2.761</br>Bumps nanoFramework.Json from 2.2.152 to 2.2.176</br>Bumps nanoFramework.Runtime.Events from 1.11.18 to 1.11.29</br>Bumps nanoFramework.System.Collections from 1.5.45 to 1.5.59</br>Bumps nanoFramework.System.Device.Wifi from 1.5.91 to 1.5.115</br>Bumps nanoFramework.System.IO.Streams from 1.1.59 to 1.1.86</br>Bumps nanoFramework.System.Net from 1.11.1 to 1.11.27</br>Bumps nanoFramework.System.Net.Http from 1.5.150 to 1.5.175</br>Bumps nanoFramework.System.Text from 1.2.54 to 1.3.16</br>Bumps nanoFramework.System.Threading from 1.1.32 to 1.1.46</br>Bumps Nerdbank.GitVersioning from 3.6.146 to 3.7.115</br>Bumps nanoFramework.Logging from 1.1.113 to 1.1.140</br>Bumps nanoFramework.TestFramework from 3.0.47 to 3.0.67</br>
[version update]

### :warning: This is an automated update. :warning:
