### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -30,13 +30,13 @@
       <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.804" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.30" />
       <dependency id="nanoFramework.System.Collections" version="1.5.62" />
-      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.123" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.88" />
-      <dependency id="nanoFramework.System.Net" version="1.11.32" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.183" />
+      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.124" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.89" />
+      <dependency id="nanoFramework.System.Net" version="1.11.34" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.184" />
       <dependency id="nanoFramework.System.Text" version="1.3.29" />
       <dependency id="nanoFramework.System.Threading" version="1.1.49" />
-      <dependency id="nanoFramework.Json" version="2.2.183" />
+      <dependency id="nanoFramework.Json" version="2.2.185" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.29" />
     </dependencies>
   </metadata>

--- a/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/MakoIoT.Device.Services.ConfigurationApi.Test.nfproj
+++ b/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/MakoIoT.Device.Services.ConfigurationApi.Test.nfproj
@@ -39,8 +39,8 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.29\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.144.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.144\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.146.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.146\lib\nanoFramework.Logging.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.TestFramework, Version=3.0.68.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.TestFramework.3.0.68\lib\nanoFramework.TestFramework.dll</HintPath>

--- a/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/packages.config
+++ b/Tests/MakoIoT.Device.Services.ConfigurationApi.Test/packages.config
@@ -3,6 +3,6 @@
   <package id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.29" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.144" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.146" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="3.0.68" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -61,8 +61,8 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.29\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Json, Version=2.2.183.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Json.2.2.183\lib\nanoFramework.Json.dll</HintPath>
+    <Reference Include="nanoFramework.Json, Version=2.2.185.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Json.2.2.185\lib\nanoFramework.Json.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.30\lib\nanoFramework.Runtime.Events.dll</HintPath>
@@ -73,17 +73,17 @@
     <Reference Include="nanoFramework.System.Text, Version=1.3.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.29\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.123.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.123\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.124.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.124\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.88.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.88\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.89.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.89\lib\System.IO.Streams.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.32\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.11.34.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.11.34\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.183.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.183\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.184.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.184\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.49.41415, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.49\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -12,13 +12,13 @@
   <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.804" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Json" version="2.2.183" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Json" version="2.2.185" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.62" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.123" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.88" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.11.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.183" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.124" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.89" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.11.34" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.184" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.49" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps nanoFramework.Json from 2.2.183 to 2.2.185</br>Bumps nanoFramework.System.Device.Wifi from 1.5.123 to 1.5.124</br>Bumps nanoFramework.System.IO.Streams from 1.1.88 to 1.1.89</br>Bumps nanoFramework.System.Net from 1.11.32 to 1.11.34</br>Bumps nanoFramework.System.Net.Http from 1.5.183 to 1.5.184</br>Bumps nanoFramework.Logging from 1.1.144 to 1.1.146</br>
[version update]

### :warning: This is an automated update. :warning:
