### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -33,7 +33,7 @@
       <dependency id="nanoFramework.System.Device.Wifi" version="1.5.128" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.91" />
       <dependency id="nanoFramework.System.Net" version="1.11.37" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.189" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.192" />
       <dependency id="nanoFramework.System.Text" version="1.3.36" />
       <dependency id="nanoFramework.System.Threading" version="1.1.50" />
       <dependency id="nanoFramework.Json" version="2.2.189" />

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -82,8 +82,8 @@
     <Reference Include="System.Net, Version=1.11.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Net.1.11.37\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.189.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.189\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.192.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.192\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.50.48563, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.50\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -18,7 +18,7 @@
   <package id="nanoFramework.System.Device.Wifi" version="1.5.128" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.91" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.189" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.192" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.50" targetFramework="netnano1.0" />
   <package id="Nerdbank.GitVersioning" version="3.7.115" targetFramework="netnano1.0" developmentDependency="true" />


### PR DESCRIPTION
Bumps nanoFramework.System.Net.Http from 1.5.189 to 1.5.192</br>
[version update]

### :warning: This is an automated update. :warning:
