### PR TITLE
Update 5 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ConfigurationApi.nuspec
+++ b/MakoIoT.Device.Services.ConfigurationApi.nuspec
@@ -17,13 +17,13 @@
     <description>REST API for configuration with MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf mako-iot configuration rest api wifimanager</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.72.2302" />
-      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.59.23023" />
-      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.158.39697" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.73.61577" />
+      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.60.45099" />
+      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.159.38871" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.65.25699" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.66.46860" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.89.37901" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.102.11591" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.103.60313" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.47.11396" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.43.34490" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />

--- a/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/MakoIoT.Device.Services.ConfigurationApi.nfproj
@@ -29,25 +29,25 @@
       <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.835\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.72.2302\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.73.61577\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.59.23023\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.60.45099\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.158.39697\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.159.38871\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.55.11594\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.65.25699\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.66.46860\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.89.37901\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.102.11591\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.103.60313\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.47.11396\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
+++ b/src/MakoIoT.Device.Services.ConfigurationApi/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.72.2302" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.59.23023" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.158.39697" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.73.61577" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.60.45099" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.159.38871" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.65.25699" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.66.46860" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.89.37901" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.102.11591" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.103.60313" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.47.11396" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.43.34490" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.72.2302 to 1.0.73.61577</br>Bumps MakoIoT.Device.Services.Configuration.Metadata from 1.0.59.23023 to 1.0.60.45099</br>Bumps MakoIoT.Device.Services.ConfigurationManager from 1.0.158.39697 to 1.0.159.38871</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.65.25699 to 1.0.66.46860</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.102.11591 to 1.0.103.60313</br>
[version update]

### :warning: This is an automated update. :warning:
